### PR TITLE
Compatibility with elixir 1.2.x and exrm 1.0.x

### DIFF
--- a/lib/mix/tasks/release.copy_rpm_templates.ex
+++ b/lib/mix/tasks/release.copy_rpm_templates.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Release.Copy_rpm_templates do
   @shortdoc "Create a copy of the Rpm Templates."
 
   use     Mix.Task
-  import  ReleaseManager.Utils
+  import  ReleaseManager.Utils.Logger
 
   @_RPM_DIR  "rpm"
   @_RPM_TEMPLATE_DIR   Path.join([@_RPM_DIR, "templates"])

--- a/lib/mix/tasks/release.rpm.copy.templates.ex
+++ b/lib/mix/tasks/release.rpm.copy.templates.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Release.Rpm.Copy.Templates do
   def run(args) do
     debug "creating copies...."
     config = [ priv_path:  Path.join([__DIR__, "..", "..", "..", "priv"]) |> Path.expand,
-               name:       Mix.config |> Keyword.get(:app) |> Atom.to_string,
+               name:       Mix.Project.config |> Keyword.get(:app) |> Atom.to_string,
              ]
     config
     |> Keyword.merge(args |> parse_args)

--- a/lib/mix/tasks/release.rpm.copy.templates.ex
+++ b/lib/mix/tasks/release.rpm.copy.templates.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Release.Copy_rpm_templates do
+defmodule Mix.Tasks.Release.Rpm.Copy.Templates do
   @moduledoc """
   Create a copy of the Rpm Templates
 

--- a/lib/mix/tasks/release.rpm.copy.templates.ex
+++ b/lib/mix/tasks/release.rpm.copy.templates.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Release.Rpm.Copy.Templates do
   def run(args) do
     debug "creating copies...."
     config = [ priv_path:  Path.join([__DIR__, "..", "..", "..", "priv"]) |> Path.expand,
-               name:       Mix.project |> Keyword.get(:app) |> Atom.to_string,
+               name:       Mix.config |> Keyword.get(:app) |> Atom.to_string,
              ]
     config
     |> Keyword.merge(args |> parse_args)

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule ExrmRpm.Mixfile do
   end
 
   defp deps do
-    [{:exrm, git: "https://github.com/bitwalker/exrm.git", tag: "0.19.6"}]
+    [{:exrm, "~> 1.0.0"}]
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExrmRpm.Mixfile do
 
   def project do
     [app: :exrm_rpm,
-     version: "0.3.0",
+     version: "0.3.2",
      elixir: "~> 1.0",
      description: description,
      package: package,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExrmRpm.Mixfile do
 
   def project do
     [app: :exrm_rpm,
-     version: "0.3.2",
+     version: "0.3.3",
      elixir: "~> 1.0",
      description: description,
      package: package,


### PR DESCRIPTION
Fixed compatibility with latest exrm and elixir.

These are backward incompatible changes. Should we increase version to 0.4.0 instead of 0.3.3?