### PR TITLE
Normalizing pre-release versions to an RPM-supported format

### DIFF
--- a/lib/exrm_rpm/exrm_rpm.ex
+++ b/lib/exrm_rpm/exrm_rpm.ex
@@ -23,6 +23,7 @@ defmodule ReleaseManager.Plugin.Rpm do
 
   @_NAME        "{{{PROJECT_NAME}}}"
   @_VERSION     "{{{PROJECT_VERSION}}}"
+  @_RELEASE     "{{{PROJECT_RELEASE}}}"
   @_TOPDIR      "{{{PROJECT_TOPDIR}}}"
   @_BUILD_ARCH  "{{{BUILD_ARCHITECTURE}}}"
   @_SUMMARY     "{{{SUMMARY}}}"
@@ -56,7 +57,6 @@ defmodule ReleaseManager.Plugin.Rpm do
 
   defp do_config(%Config{name: name, version: version} = config) do
     app_name   = "#{name}-#{version}.tar.gz"
-    source_name   = "#{name}-#{version |> normalize_version}.tar.gz"
     build_dir  = config |> get_config_item(:build_dir,  build_dir())
     build_arch = config |> get_config_item(:build_arch, @_DEFAULT_BUILD_ARCH)
 
@@ -72,7 +72,7 @@ defmodule ReleaseManager.Plugin.Rpm do
         rpmbuild:        @_RPM_BUILD_TOOL,
         rpmbuild_opts:   @_RPM_BUILD_ARGS,
         priv_path:       Path.join([__DIR__, "..", "..", "priv"]) |> Path.expand,
-        sources_path:    Path.join([build_dir, "SOURCES", source_name]),
+        sources_path:    Path.join([build_dir, "SOURCES", app_name]),
         target_rpm_path: Path.join([File.cwd!, "rel", name, "releases", version, rpm_file_name(name, version, build_arch)]),
         app_tar_path:    Path.join([File.cwd!, "rel", name, app_name]),
         summary:         @_DEFAULT_SUMMARY,
@@ -93,6 +93,7 @@ defmodule ReleaseManager.Plugin.Rpm do
     contents = File.read!(spec)
     |> String.replace(@_NAME, config.name)
     |> String.replace(@_VERSION, config.version |> normalize_version)
+    |> String.replace(@_RELEASE, config.version)
     |> String.replace(@_TOPDIR, config.build_dir)
     |> String.replace(@_BUILD_ARCH, config.build_arch)
     |> String.replace(@_SUMMARY, config.summary)

--- a/lib/exrm_rpm/exrm_rpm.ex
+++ b/lib/exrm_rpm/exrm_rpm.ex
@@ -115,8 +115,23 @@ defmodule ReleaseManager.Plugin.Rpm do
     config
   end
 
-  defp normalize_version(version) do
-    version |> String.split([".", "-"]) |> Enum.map(fn(segment) ->  Regex.replace(~r/[^0-9]+/, segment, "") end) |> Enum.join(".")
+  defp normalize_version(version) when is_binary(version) do
+    version |> String.split([".", "-"]) |> normalize_version |> Enum.join(".")
+  end
+  defp normalize_version(v = [_maj, _min, _patch]) do
+    v
+  end
+  defp normalize_version(v = [maj, _min, _patch, _pre]) when is_binary(maj) do
+    normalize_version(v |> Enum.map(fn(segment) -> Regex.replace(~r/[^0-9]+/, segment, "") |> String.to_integer end))
+  end
+  defp normalize_version([maj, 0, 0, pre]) when maj > 0 do
+    [maj - 1, 99, 99, 99, pre]
+  end
+  defp normalize_version([maj, min, 0, pre]) when min > 0 do
+    [maj, min - 1, 99, 99, pre]
+  end
+  defp normalize_version([maj, min, patch, pre]) when patch > 0 do
+    [maj, min, patch - 1, 99, pre]
   end
 
   defp copy_extra_sources(config) do

--- a/priv/rel/files/spec
+++ b/priv/rel/files/spec
@@ -1,6 +1,7 @@
 %define install_dir     /usr/local
 %define _topdir         {{{PROJECT_TOPDIR}}}
 %define temp_dir       /tmp
+%define erl_release    {{{PROJECT_RELEASE}}}
 Name:    {{{PROJECT_NAME}}}
 Version: {{{PROJECT_VERSION}}}
 
@@ -12,7 +13,7 @@ Summary: {{{SUMMARY}}}
 Group:         Applications
 License:       GPL
 URL:           https://github.com/bitwalker/exrm
-Source0:       %{name}-%{version}.tar.gz
+Source0:       %{name}-%{erl_release}.tar.gz
 Source1:       %{name}
 BuildRoot:     %{_tmppath}/%{name}-root
 BuildArchitectures: {{{BUILD_ARCHITECTURE}}}
@@ -36,15 +37,15 @@ rm -rf $RPM_BUILD_ROOT
 %post
 if [ $1 -eq 1 ]; then
     # new install
-    tar xzf %{temp_dir}/%{name}-%{version}.tar.gz -C %{install_dir}/%{name}
-    rm %{temp_dir}/%{name}-%{version}.tar.gz
+    tar xzf %{temp_dir}/%{name}-%{erl_release}.tar.gz -C %{install_dir}/%{name}
+    rm %{temp_dir}/%{name}-%{erl_release}.tar.gz
     /sbin/chkconfig --add %{name}
     /sbin/service %{name} start  > /dev/null 2>&1
 else
     # upgrade
-    mkdir %{install_dir}/%{name}/releases/%{version}
-    mv %{temp_dir}/%{name}-%{version}.tar.gz %{install_dir}/%{name}/releases/%{version}/%{name}.tar.gz
-    cd %{install_dir}/%{name} && bin/%{name} upgrade "%{version}"
+    mkdir %{install_dir}/%{name}/releases/%{erl_release}
+    mv %{temp_dir}/%{name}-%{erl_release}.tar.gz %{install_dir}/%{name}/releases/%{erl_release}/%{name}.tar.gz
+    cd %{install_dir}/%{name} && bin/%{name} upgrade "%{erl_release}"
 fi
 exit 0
 
@@ -59,7 +60,7 @@ exit 0
 
 %files
 %defattr(-, root, root, -)
-%{temp_dir}/%{name}-%{version}.tar.gz
+%{temp_dir}/%{name}-%{erl_release}.tar.gz
 %dir %{install_dir}/%{name}
 
 %defattr(755, root, root, -)


### PR DESCRIPTION
I'm trying to build RPMs from pre-release commits, and Mix enforces the semantic versioning format `1.2.3-dev4`, but dashes are not allowed in RPM version strings. The recommended way is to put the non-numeric part in the RPM release string, but exrm_rpm says this is not supported (why exactly?)

This patch will translate versions with non-numeric parts to `1.2.2.99.4` when talking to rpmbuild to keep everyone more or less happy.
